### PR TITLE
feat(core): add an option to seperate the output of show …

### DIFF
--- a/docs/generated/cli/show.md
+++ b/docs/generated/cli/show.md
@@ -145,6 +145,12 @@ Type: `string`
 
 Show only projects that match a given pattern.
 
+##### sep
+
+Type: `string`
+
+Outputs projects with the specified seperator
+
 ##### type
 
 Type: `string`

--- a/docs/generated/packages/nx/documents/show.md
+++ b/docs/generated/packages/nx/documents/show.md
@@ -145,6 +145,12 @@ Type: `string`
 
 Show only projects that match a given pattern.
 
+##### sep
+
+Type: `string`
+
+Outputs projects with the specified seperator
+
 ##### type
 
 Type: `string`

--- a/packages/nx/src/command-line/show/command-object.ts
+++ b/packages/nx/src/command-line/show/command-object.ts
@@ -23,6 +23,7 @@ export type ShowProjectsOptions = NxShowArgs & {
   projects: string[];
   withTarget: string[];
   verbose: boolean;
+  sep: string;
 };
 
 export type ShowProjectOptions = NxShowArgs & {
@@ -89,6 +90,10 @@ const showProjectsCommand: CommandModule<NxShowArgs, ShowProjectsOptions> = {
         type: 'string',
         description: 'Select only projects of the given type',
         choices: ['app', 'lib', 'e2e'],
+      })
+      .option('sep', {
+        type: 'string',
+        description: 'Outputs projects with the specified seperator',
       })
       .implies('untracked', 'affected')
       .implies('uncommitted', 'affected')

--- a/packages/nx/src/command-line/show/show.spec.ts
+++ b/packages/nx/src/command-line/show/show.spec.ts
@@ -1,0 +1,37 @@
+import { ProjectGraphProjectNode } from '../../devkit-exports';
+import { createTreeWithEmptyWorkspace } from '../../generators/testing-utils/create-tree-with-empty-workspace';
+import { Tree } from '../../generators/tree';
+import { addProjectConfiguration } from '../../generators/utils/project-configuration';
+import { showProjectsHandler } from './show';
+
+describe('show', () => {
+  let appTree: Tree;
+
+  beforeEach(() => {
+    appTree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    addProjectConfiguration(appTree, 'proj1', { root: 'proj1' });
+    addProjectConfiguration(appTree, 'proj2', { root: 'proj2' });
+    addProjectConfiguration(appTree, 'proj3', { root: 'proj3' });
+  });
+
+  it('should print out projects with provided seperator value', async () => {
+    jest.spyOn(console, 'log');
+
+    await showProjectsHandler({
+      exclude: '',
+      files: '',
+      uncommitted: false,
+      untracked: false,
+      base: '',
+      head: '',
+      affected: false,
+      type: 'lib',
+      projects: [],
+      withTarget: [],
+      verbose: false,
+      sep: ',',
+    });
+
+    expect(console.log).toHaveBeenCalledWith('proj1,proj2,proj3');
+  });
+});

--- a/packages/nx/src/command-line/show/show.ts
+++ b/packages/nx/src/command-line/show/show.ts
@@ -75,11 +75,14 @@ export async function showProjectsHandler(
 
   if (args.json) {
     console.log(JSON.stringify(Array.from(selectedProjects)));
+  } else if (args.sep) {
+    console.log(Array.from(selectedProjects.values()).join(args.sep));
   } else {
     for (const project of selectedProjects) {
       console.log(project);
     }
   }
+
   await output.drain();
   process.exit(0);
 }


### PR DESCRIPTION
…with provided character

`npx nx show projects --affected --type=app --sep ","` will output the affected projects with a "," seperating each project ouput

closed #22219

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
